### PR TITLE
fix: correct permissions for write

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,8 @@ on:
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
 
+permissions: read-all
+
 jobs:
   collectInputs:
     name: Collect workflow inputs

--- a/.github/workflows/semantic-releaser.yml
+++ b/.github/workflows/semantic-releaser.yml
@@ -8,6 +8,8 @@ on:
       - '**.tf'
       - '!examples/**.tf'
 
+permissions: read-all
+
 jobs:
   release:
     name: Release

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "bucket" {
       "s3:PutObject",
     ]
 
-    resources = [for o in var.account_trails : "${local.bucket_arn}/AWSLogs/${o.account}"]
+    resources = [for o in var.account_trails : "${local.bucket_arn}/AWSLogs/${o.account}/*"]
 
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
The write perm needs a wildcard to write into the key prefix for the account, this was dropped during a refactor.  

Also sneaking in a GHA Workflow fix to mollify checkov that popped up in this PR since we just turned that check on and this is the first time it ran in the environment.